### PR TITLE
lib/main: change the getRequestInfo() logic

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -48,6 +48,7 @@ function getDownloadCommands(httpChannel, filename) {
  * Return the basic HTTP request info contained in a nsIHttpChannel.
  *
  * @param nsIHttpChannel httpChannel
+ * @param bool ignoreCache
  * @return {
  *   uri: string
  *   method: string "POST" or "GET"
@@ -55,7 +56,14 @@ function getDownloadCommands(httpChannel, filename) {
  *   headers: []string
  * }
  */
-function getRequestInfo(channel) {
+function getRequestInfo(channel, ignoreCache) {
+
+  let url = channel.URI.spec;
+  if (!ignoreCache)
+    for (let req of recentRequests)
+      if (req && req.url == url)
+        return req.info;
+
   if (channel instanceof Ci.nsIHttpChannel) {
     let headerVisitor = {
       headers: [],
@@ -72,15 +80,11 @@ function getRequestInfo(channel) {
       headers: headerVisitor.headers,
       method: channel.requestMethod,
       payload: payload,
-      uri: channel.URI.spec,
+      uri: url
     };
-  } else {
-    let url = channel.URI.spec;
-    for (let req of recentRequests)
-      if (req && req.url == url)
-        return req.info;
-    return null;
   }
+
+  return null;
 }
 
 /**
@@ -270,7 +274,7 @@ if (runtime.browserTabsRemoteAutostart) {
     recentRequestsIdx = ++recentRequestsIdx % prefs.request_header_cache_size;
     recentRequests[recentRequestsIdx] = {
       url: channel.QueryInterface(Ci.nsIChannel).URI.spec,
-      info: getRequestInfo(channel.QueryInterface(Ci.nsIHttpChannel))
+      info: getRequestInfo(channel.QueryInterface(Ci.nsIHttpChannel), true)
     };
   }, true);
 }


### PR DESCRIPTION
In some cases, the command generated by `Copy EXEC for page` menu does not work because some important data, such as cookies, is missing from the headers.
This commit makes `getRequestInfo()` always searches the cache of recent requests, if, no additional parameter is supplied, in attempt to solve those cases.