### PR TITLE
Pale Moon 27.1+ support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   "icon64": "data/icon64.png",
   "main": "lib/main.js",
 
+  "engines": {
+    "firefox": ">=38.0a1",
+    "{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
+  },
+
   "permissions": {"private-browsing": true},
 
   "preferences" : [{


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](https://github.com/JustOff/pm27-sdk-addons/blob/master/PMkit.md), tested with [Pale Moon 27.1.0beta](http://www.palemoon.org/unstable/).