### PR TITLE
Stop erroneously tracking XHTML pages as downloads

### DIFF
--- a/background.js
+++ b/background.js
@@ -185,6 +185,7 @@ function onResponseStarted(details) {
       contentType.startsWith("text/html") ||
       contentType.startsWith("text/plain") ||
       contentType.startsWith("image/") ||
+      contentType.startsWith("application/xhtml") ||
       contentType.startsWith("application/xml")
     )
       return;


### PR DESCRIPTION
This PR stops cliget from falsely triggering on accessing XHTML Web pages that have "application/xhtml+xml" set as their Content-Type and do not explicitly set Content-Disposition.
Examples include [1] and [2], as well as any gitweb instance.

[1] http://www.schillmania.com/content/entries/2004/10/24/application-xhtml+xml/
[2] http://git.altlinux.org/gears/s/sisyphus_check.git