### PR TITLE
--body-data will now also be escaped

### DIFF
--- a/wget.js
+++ b/wget.js
@@ -32,7 +32,7 @@ window.wget = function (url, method, headers, payload, filename, options) {
   if (payload)
     if (payload.formData) {
       if (contentType === "application/x-www-form-urlencoded")
-        parts.push(`--body-data ${window.toQueryString(payload.formData)}`);
+        parts.push(`--body-data ${esc(window.toQueryString(payload.formData))}`);
       else if (contentType.startsWith("multipart/form-data;"))
         throw new Error("Unsupported upload data");
     } else if (payload.raw) {


### PR DESCRIPTION
There was a Problem with a OneDrive Download, where I got a Bash error. The Problem could be solved by also escaping the --body-data in the generated wget command.
Here is a patched version of cliget.